### PR TITLE
add new gpg key for rvm

### DIFF
--- a/manifests/gnupg_key.pp
+++ b/manifests/gnupg_key.pp
@@ -1,6 +1,7 @@
 # RVM's GPG key import
 class rvm::gnupg_key(
   $key_id     = $rvm::params::gnupg_key_id,
+  $key_server = $rvm::params::key_server,
   $key_source = $rvm::params::key_source,
 ) inherits rvm::params {
 
@@ -8,6 +9,7 @@ class rvm::gnupg_key(
     ensure     => present,
     key_id     => $key_id,
     user       => 'root',
+    key_server => $key_server,
     key_source => $key_source,
     key_type   => public,
   }

--- a/manifests/gnupg_key.pp
+++ b/manifests/gnupg_key.pp
@@ -1,14 +1,14 @@
 # RVM's GPG key import
-
 class rvm::gnupg_key(
-  $key_id = $rvm::params::gnupg_key_id,
-  $key_server = $rvm::params::key_server) inherits rvm::params {
+  $key_id     = $rvm::params::gnupg_key_id,
+  $key_source = $rvm::params::key_source,
+) inherits rvm::params {
 
   gnupg_key { "rvm_${key_id}":
     ensure     => present,
     key_id     => $key_id,
     user       => 'root',
-    key_server => $key_server,
+    key_source => $key_source,
     key_type   => public,
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,13 +10,13 @@ class rvm::params($manage_group = true) {
     default => 'rvm',
   }
 
-  $proxy_url = undef
-  $no_proxy = undef
-  $key_server = 'hkp://keys.gnupg.net'
+  $proxy_url  = undef
+  $no_proxy   = undef
+  $key_source = 'https://rvm.io/pkuczynski.asc'
 
   # install the gpg key if gpg is installed or being installed in this puppet run
   if defined(Class['::gnupg']) or $::gnupg_installed {
-    $gnupg_key_id = 'D39DC0E3'
+    $gnupg_key_id = '39499BDB'
   } else {
     $gnupg_key_id = false
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,7 @@ class rvm::params($manage_group = true) {
 
   $proxy_url  = undef
   $no_proxy   = undef
+  $key_server = 'hkp://keys.gnupg.net'
   $key_source = 'https://rvm.io/pkuczynski.asc'
 
   # install the gpg key if gpg is installed or being installed in this puppet run


### PR DESCRIPTION
```
==> default: Notice: /Stage[main]/Rvm::Gnupg_key/Gnupg_key[rvm_D39DC0E3]/ensure: created
==> default: Notice: /Stage[main]/Rvm::System/Exec[system-rvm]/returns: Downloading https://github.com/rvm/rvm/archive/1.29.8.tar.gz
==> default: Notice: /Stage[main]/Rvm::System/Exec[system-rvm]/returns: Downloading https://github.com/rvm/rvm/releases/download/1.29.8/1.29.8.tar.gz.asc
==> default: Notice: /Stage[main]/Rvm::System/Exec[system-rvm]/returns: gpg: Signature made Wed May  8 14:14:49 2019 UTC
==> default: Notice: /Stage[main]/Rvm::System/Exec[system-rvm]/returns: gpg:                using RSA key 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
==> default: Notice: /Stage[main]/Rvm::System/Exec[system-rvm]/returns: gpg: Can't check signature: No public key
==> default: Notice: /Stage[main]/Rvm::System/Exec[system-rvm]/returns: GPG signature verification failed for '/usr/local/rvm/archives/rvm-1.29.8.tgz' - 'https://github.com/rvm/rvm/releases/download/1.29.8/1.29.8.tar.gz.asc'! Try to install GPG v2 and then fetch the public key:
==> default: Notice: /Stage[main]/Rvm::System/Exec[system-rvm]/returns: 
==> default: Notice: /Stage[main]/Rvm::System/Exec[system-rvm]/returns:     sudo gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
==> default: Notice: /Stage[main]/Rvm::System/Exec[system-rvm]/returns: 
==> default: Notice: /Stage[main]/Rvm::System/Exec[system-rvm]/returns: or if it fails:
==> default: Notice: /Stage[main]/Rvm::System/Exec[system-rvm]/returns: 
==> default: Notice: /Stage[main]/Rvm::System/Exec[system-rvm]/returns:     command curl -sSL https://rvm.io/mpapis.asc | sudo gpg --import -
==> default: Notice: /Stage[main]/Rvm::System/Exec[system-rvm]/returns:     command curl -sSL https://rvm.io/pkuczynski.asc | sudo gpg --import -
==> default: Notice: /Stage[main]/Rvm::System/Exec[system-rvm]/returns: 
==> default: Notice: /Stage[main]/Rvm::System/Exec[system-rvm]/returns: In case of further problems with validation please refer to https://rvm.io/rvm/security
==> default: Error: 'curl -fsSL https://get.rvm.io | bash -s -- --version latest' returned 2 instead of one of [0]
==> default: Error: /Stage[main]/Rvm::System/Exec[system-rvm]/returns: change from 'notrun' to ['0'] failed: 'curl -fsSL https://get.rvm.io | bash -s -- --version latest' returned 2 instead of one of [0]
```