### PR TITLE
Remove procs from title patterns

### DIFF
--- a/lib/puppet/type/rvm_gem.rb
+++ b/lib/puppet/type/rvm_gem.rb
@@ -2,7 +2,7 @@ Puppet::Type.newtype(:rvm_gem) do
   @doc = 'Ruby Gem support using RVM.'
 
   def self.title_patterns
-    [[%r{/^(?:(.*)\/)?(.*)$/}, [[:ruby_version, ->(x) { x }], [:name, ->(x) { x }]]]]
+    [[%r{/^(?:(.*)\/)?(.*)$/}, [[:ruby_version], [:name]]]]
   end
 
   ensurable do

--- a/lib/puppet/type/rvm_gemset.rb
+++ b/lib/puppet/type/rvm_gemset.rb
@@ -2,7 +2,7 @@ Puppet::Type.newtype(:rvm_gemset) do
   @doc = 'Manage RVM Gemsets.'
 
   def self.title_patterns
-    [[%r{^(?:(.*)@)?(.*)$}, [[:ruby_version, ->(x) { x }], [:name, ->(x) { x }]]]]
+    [[%r{^(?:(.*)@)?(.*)$}, [[:ruby_version], [:name]]]]
   end
 
   ensurable


### PR DESCRIPTION
The existing lambdas appear to be breaking compilation recently, and have been removed in other puppet modules to fix the same issue[1][2].

[1] https://github.com/voxpupuli/puppet-rvm/commit/7f697ee69f3485efd23ff501ebdfeeb7b4362676
[2] https://github.com/puppetlabs/puppetlabs-java_ks/commit/27ced479906cbf28b6db169cf06b227d092adb58
